### PR TITLE
Few updates

### DIFF
--- a/aio.go
+++ b/aio.go
@@ -2,13 +2,24 @@ package aio
 
 import (
 	"os"
-	//	"github.com/missionMeteora/toolkit/errors"
+	"runtime"
 )
 
-// New returns a new AIO
-func New(numThreads int) *AIO {
+//	"github.com/missionMeteora/toolkit/errors"
+
+// New is an alias for NewNum(runtime.NumCPU())
+func New() *AIO {
+	return NewNum(runtime.NumCPU())
+}
+
+// NewNum returns a new AIO with the specific number of workers.
+func NewNum(numThreads int) *AIO {
 	a := AIO{
-		rq: make(chan interface{}, 1024),
+		rq: make(chan interface{}, ulimitNoFile()),
+	}
+
+	if numThreads < 1 {
+		numThreads = 1
 	}
 
 	for i := 0; i < numThreads; i++ {

--- a/aio_nix.go
+++ b/aio_nix.go
@@ -1,0 +1,18 @@
+// +build linux
+
+package aio
+
+import (
+	"log"
+	"syscall"
+)
+
+func ulimitNoFile() int {
+	var rl syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	return int(rl.Cur)
+}

--- a/aio_other.go
+++ b/aio_other.go
@@ -1,0 +1,5 @@
+// +build !linux
+
+package aio
+
+func ulimitNoFile() int { return 1024 }

--- a/aio_test.go
+++ b/aio_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-var ta = New(2)
+var ta = New()
 var testBuf = bytes.NewBuffer(nil)
 
 const (
@@ -23,19 +23,19 @@ func TestBasic(t *testing.T) {
 		oresp *OpenResp
 	)
 
-	aio := New(2)
+	aio := New()
 
-	if oresp = <-aio.Open("./testing/helloWorld.txt"); oresp.err != nil {
-		t.Fatal(oresp.err)
+	if oresp = <-aio.Open("./testing/helloWorld.txt"); oresp.Err != nil {
+		t.Fatal(oresp.Err)
 	}
 
-	f = oresp.f
+	f = oresp.F
 
-	if oresp = <-aio.OpenFile("./testing/testWrite.txt", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600); oresp.err != nil {
-		t.Fatal(oresp.err)
+	if oresp = <-aio.OpenFile("./testing/testWrite.txt", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600); oresp.Err != nil {
+		t.Fatal(oresp.Err)
 	}
 
-	wf = oresp.f
+	wf = oresp.F
 
 	var (
 		buf [32]byte
@@ -62,11 +62,11 @@ func TestBasic(t *testing.T) {
 	}
 
 	or := <-ta.Open(testFilePath)
-	if or.err != nil {
+	if or.Err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := io.Copy(testBuf, or.f); err != nil {
+	if _, err := io.Copy(testBuf, or.F); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -75,15 +75,15 @@ func BenchmarkAIO(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		testBuf.Reset()
 		or := <-ta.Open(testFilePath)
-		if or.err != nil {
-			b.Fatal(or.err)
+		if or.Err != nil {
+			b.Fatal(or.Err)
 		}
 
-		if _, err := io.Copy(testBuf, or.f); err != nil {
+		if _, err := io.Copy(testBuf, or.F); err != nil {
 			b.Fatal(err)
 		}
 
-		if err := or.f.Close(); err != nil {
+		if err := or.F.Close(); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -117,15 +117,15 @@ func BenchmarkAIOPara(b *testing.B) {
 		buf := bytes.NewBuffer(nil)
 		for pb.Next() {
 			or := <-ta.Open(testFilePath)
-			if or.err != nil {
-				b.Fatal(or.err)
+			if or.Err != nil {
+				b.Fatal(or.Err)
 			}
 
-			if _, err := io.Copy(buf, or.f); err != nil {
+			if _, err := io.Copy(buf, or.F); err != nil {
 				b.Fatal(err)
 			}
 
-			if err := or.f.Close(); err != nil {
+			if err := or.F.Close(); err != nil {
 				b.Fatal(err)
 			}
 

--- a/cmd/serveWebFile/main.go
+++ b/cmd/serveWebFile/main.go
@@ -1,22 +1,25 @@
 package main
 
 import (
-	"github.com/itsmontoya/aio"
-	"github.com/julienschmidt/httprouter"
 	"io"
+	"log"
 	"net/http"
 	"os"
+
+	"github.com/OneOfOne/aio"
+	"github.com/julienschmidt/httprouter"
 )
 
 func main() {
 	s := &srv{
-		aio: aio.New(2),
+		aio: aio.NewNum(2),
+		// aio: aio.New(), using numCpu slows it down
 	}
 
 	r := httprouter.New()
 	r.GET("/a", s.handleA)
 	r.GET("/b", s.handleB)
-	http.ListenAndServe(":1337", r)
+	log.Fatal(http.ListenAndServe(":1337", r))
 }
 
 type srv struct {


### PR DESCRIPTION
1. Use `ulimit -n` rather than a random number for the queue.
2. Use runtime.NumCPU() by default.
